### PR TITLE
Fix NullPointerException on some devices

### DIFF
--- a/toasty/src/main/java/es/dmoral/toasty/Toasty.java
+++ b/toasty/src/main/java/es/dmoral/toasty/Toasty.java
@@ -168,7 +168,7 @@ public class Toasty {
     public static Toast custom(@NonNull Context context, @NonNull CharSequence message, Drawable icon,
                                @ColorInt int tintColor, int duration,
                                boolean withIcon, boolean shouldTint) {
-        final Toast currentToast = Toast.makeText(context, null, duration);
+        final Toast currentToast = new Toast(context);
         final View toastLayout = ((LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE))
                 .inflate(R.layout.toast_layout, null);
         final ImageView toastIcon = toastLayout.findViewById(R.id.toast_icon);
@@ -196,6 +196,7 @@ public class Toasty {
         toastTextView.setTypeface(currentTypeface);
         toastTextView.setTextSize(TypedValue.COMPLEX_UNIT_SP, textSize);
 
+        currentToast.setDuration(duration);
         currentToast.setView(toastLayout);
         return currentToast;
     }


### PR DESCRIPTION
Hi!
I've had the same issue as #60 on some Android devices.

Although this is a device-specific issue, it seems it could be fixed by replacing
`final Toast currentToast = Toast.makeText(context, null, duration);`
with
`final Toast currentToast = new Toast(context);  
 currentToast.setDuration(duration);`
or 
`final Toast currentToast = Toast.makeText(context, "", duration);`

Providing null param to the Toast.makeText function violates its `@NonNull` annotation.
Despite the fact that everything works well on most devices, it's better to be safe from crashes.
Also using constructor instead of makeText allows to avoid unnecessary layout inflation.