### PR TITLE
Added Support for React Native Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,7 @@ shouldTint).show();
 ## Third Party Bindings
 
 ### React Native
-You may now use this library with [React Native](https://github.com/facebook/react-native) via the module [here](https://github.com/prscX/react-native-toasty)
-
+You may now use this library with [React Native](https://github.com/facebook/react-native) via this [module](https://github.com/prscX/react-native-toasty).
 
 Apps using Toasty
 --

--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ shouldTint).show();
 
 <img src="https://raw.githubusercontent.com/GrenderG/Toasty/master/art/collage.png">
 
+## Third Party Bindings
+
+### React Native
+You may now use this library with [React Native](https://github.com/facebook/react-native) via the module [here](https://github.com/prscX/react-native-toasty)
+
+
 Apps using Toasty
 --
 


### PR DESCRIPTION
Hi @GrenderG, 

First of all I would like to appreciate for creating such a cool toast library.

I have created a React Native bridge plugin for using this library with React Native projects.

I have added the same in `README`. Can you please merge this request so that if someone looking to use this library for React Native projects can easily do the same.

Please let me know in case any changes are required

[react-native-toasty](https://github.com/prscX/react-native-toasty)

Thanks
Pranav