### PR TITLE
improvement

### DIFF
--- a/toasty/src/main/java/es/dmoral/toasty/Toasty.java
+++ b/toasty/src/main/java/es/dmoral/toasty/Toasty.java
@@ -294,7 +294,8 @@ public class Toasty {
     public static Toast custom(@NonNull Context context, @NonNull CharSequence message, Drawable icon,
                                @ColorInt int tintColor, @ColorInt int textColor, int duration,
                                boolean withIcon, boolean shouldTint) {
-        final Toast currentToast = Toast.makeText(context, "", duration);
+        final Toast currentToast = new Toast(context);
+        currentToast.setDuration(duration);
         final View toastLayout = ((LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE))
                 .inflate(R.layout.toast_layout, null);
         final ImageView toastIcon = toastLayout.findViewById(R.id.toast_icon);


### PR DESCRIPTION
Hey, 
Trying to do bit of improvement here.
In custom() method if we call Toast.makeText() it will **inflate default view** and get the view inside and set data. which is not needed when you are setting custom view to Toast before show(). it will always available for garbage collection as soon as we call setView method. 
 **Here there is always one extra layout inflation per toast.**
if any question please write me back.
Cheers!
Anuj