### PR TITLE
Added RTL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Toasty.Config.getInstance()
     .setToastTypeface(@NonNull Typeface typeface) // optional
     .setTextSize(int sizeInSp) // optional
     .allowQueue(boolean allowQueue) // optional (prevents several Toastys from queuing)
+    .setRTL(boolean isRTL) // optional (icon is on the right)
     .apply(); // required
 ```
 

--- a/toasty/src/main/java/es/dmoral/toasty/Toasty.java
+++ b/toasty/src/main/java/es/dmoral/toasty/Toasty.java
@@ -10,10 +10,12 @@ import androidx.annotation.ColorRes;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
+import android.os.Build;
 import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
@@ -42,6 +44,7 @@ public class Toasty {
 
     private static boolean tintIcon = true;
     private static boolean allowQueue = true;
+    private static boolean isRTL = false;
 
     private static Toast lastToast = null;
 
@@ -300,6 +303,7 @@ public class Toasty {
         final Toast currentToast = Toast.makeText(context, "", duration);
         final View toastLayout = ((LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE))
                 .inflate(R.layout.toast_layout, null);
+        final LinearLayout toast_root = toastLayout.findViewById(R.id.toast_root);
         final ImageView toastIcon = toastLayout.findViewById(R.id.toast_icon);
         final TextView toastTextView = toastLayout.findViewById(R.id.toast_text);
         Drawable drawableFrame;
@@ -313,6 +317,8 @@ public class Toasty {
         if (withIcon) {
             if (icon == null)
                 throw new IllegalArgumentException("Avoid passing 'icon' as null if 'withIcon' is set to true");
+            if (isRTL && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
+                toast_root.setLayoutDirection(View.LAYOUT_DIRECTION_RTL);
             ToastyUtils.setBackground(toastIcon, tintIcon ? ToastyUtils.tintIcon(icon, textColor) : icon);
         } else {
             toastIcon.setVisibility(View.GONE);
@@ -340,6 +346,7 @@ public class Toasty {
 
         private boolean tintIcon = Toasty.tintIcon;
         private boolean allowQueue = true;
+        private boolean isRTL = false;
 
         private Config() {
             // avoiding instantiation
@@ -355,6 +362,7 @@ public class Toasty {
             Toasty.textSize = 16;
             Toasty.tintIcon = true;
             Toasty.allowQueue = true;
+            Toasty.isRTL = false;
         }
 
         @CheckResult
@@ -381,11 +389,18 @@ public class Toasty {
             return this;
         }
 
+        @CheckResult
+        public Config setRTL(boolean isRTL) {
+            this.isRTL = isRTL;
+            return this;
+        }
+
         public void apply() {
             Toasty.currentTypeface = typeface;
             Toasty.textSize = textSize;
             Toasty.tintIcon = tintIcon;
             Toasty.allowQueue = allowQueue;
+            Toasty.isRTL = isRTL;
         }
     }
 }


### PR DESCRIPTION
For RTL languages icons should be on the right side.
I've added a new optional config to set whether it's RTL or not ('isRTL').
• If 'isRTL' is set to true the toast icon will be shown on the right side.
![image](https://user-images.githubusercontent.com/7678128/127747779-ae7354ff-8fae-4a48-9ad6-779d6e551578.png)
• If 'isRTL' is set to false the toast icon will be shown on the left side.
![image](https://user-images.githubusercontent.com/7678128/127747838-4492f983-c038-470b-9731-75af13903a9d.png)