### PR TITLE
Android 12 issue fixed

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,7 +8,8 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity android:name=".MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
Hi, @GrenderG 
Firstly, great work on the library! Loved it!
I wanted to raise an issue, as per android documentation, 
`As of Android 12, android:exported must be set; use true to make the activity available to other apps, and false otherwise. For launcher activities, this should be set to true.`
I see that the compileSdkVersion of the library is 31, because of which the Sample App is not working, as the launcher activity does not have `android:exported = "true"`, because of which the sample app is not getting installed. 
I have raised a PR for the same, I request you to please review it and then merge it. 

Thanks!

![Screenshot 2022-06-02 at 3 44 37 PM](https://user-images.githubusercontent.com/41950568/171609958-bd760ea6-2a46-487a-9158-2e2b433b9430.png)
![Screenshot 2022-06-02 at 3 46 28 PM](https://user-images.githubusercontent.com/41950568/171609985-a8383e6f-6a54-477f-9fd3-34f58e15cbd9.png)

